### PR TITLE
fixing Logo.svg use in navbar to use public folder

### DIFF
--- a/src/common/navbar.js
+++ b/src/common/navbar.js
@@ -91,7 +91,7 @@ class NavBar extends React.Component {
                 {/* should contain logo which links back to home page */}
                 <div className="left">
                     <Link to="/">
-                        <img alt="CircleSpace" src="/logo.svg" />
+                        <img alt="CircleSpace" src="./Logo.svg" />
                     </Link>
                 </div>
                 {/* should contain search bar */}


### PR DESCRIPTION
Logo was not appearing in navbar due to file location.
Moved file to public so that it can be accessed client side.