### PR TITLE
added logout, correct profile redirection, https only

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,15 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>CircleSpace</title>
+    
+    <!-- Always use https for localStorage. http and https are treated as different origins and thus have
+    their own individual localStorages. This is run in the HTML <head> so that it checks before any React scripts are loaded. -->
+    <script>
+      var host = "circlespace.herokuapp.com";
+      if ((host === window.location.host) && (window.location.protocol !== "https:")){
+      window.location.protocol = "https";
+      }
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -57,7 +57,6 @@ export const signup = ({ firstname, lastname, username, email, password}) => dis
 }
 
 export const login = ({email, password}) => dispatch => {
-    console.log('called login')
     // Headers
     const config = {
         headers: {

--- a/src/common/navbar.js
+++ b/src/common/navbar.js
@@ -4,7 +4,7 @@ import Searchbar from './searchbar.js';
 import './navbar.css'
 
 import { connect } from 'react-redux'
-// import { logout } from '../actions/authActions'
+import { logout } from '../actions/authActions'
 import PropTypes from 'prop-types';
 
 class NavBar extends React.Component {
@@ -24,7 +24,8 @@ class NavBar extends React.Component {
 
     static propTypes = {
         auth: PropTypes.object.isRequired,
-        logout: PropTypes.func.isRequired
+        logout: PropTypes.func.isRequired,
+        user: PropTypes.object
     }
 
     componentDidMount() {
@@ -34,7 +35,8 @@ class NavBar extends React.Component {
     }
 
     LoggedInRender() {
-        let profilelink = '/profile/' + this.state.userid;
+        const { username } = this.props.user;
+        let profilelink = '/profile/' + username;
         return (
             <div className="row">
                 <Link to={profilelink}>
@@ -42,6 +44,9 @@ class NavBar extends React.Component {
                     {/* profile picture */}
                     {/* profile name */}
                     <h2>Profile</h2>
+                </Link>
+                <Link onClick={this.props.logout} to='/'>
+                    <h2>Logout</h2>
                 </Link>
                 {/* <Link onClick={this.props.logout} href='#'>
                     Logout
@@ -123,10 +128,11 @@ class NavBar extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    auth: state.auth
+    auth: state.auth,
+    user: state.auth.user
 })
 
 export default connect(
     mapStateToProps,
-    null
+    { logout }
 )(NavBar)

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -45,7 +45,7 @@ export default function(state = initialState, action) {
         case LOGIN_FAIL:
         case LOGOUT_SUCCESS:
         case REGISTER_FAIL:
-            localStorage.removeItem('token')
+            localStorage.removeItem('token');
             return {
                 ...state,
                 token: null,


### PR DESCRIPTION
- Logout function in navbar appears once logged in
- Clicking 'Logout' deletes JWT and returns you to home page
- Added correct redirection for 'Profile' button. Clicking Profile will use the username stored in global state to redirect to that user's profile page.
- Added script in public/index.html to only use HTTPS as HTTP and HTTPS use different storages (annoying if a user swaps between HTTPS and HTTP mid session as they lose their state).

