### PR TITLE
Edit Bio - Name, Bio Text, DP

### DIFF
--- a/src/user/editProjects/editBioPane.js
+++ b/src/user/editProjects/editBioPane.js
@@ -1,15 +1,26 @@
+import axios from "axios";
 import React from "react";
+import { API_DOMAIN } from "../../config";
 import './editProjectsPane.css';
 
 class EditBioPane extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            changePicture: false
+            changePicture: false,
+            saveBioText: "Save",
+            firstname: this.props.user.firstname,
+            lastname: this.props.user.lastname,
+            bio: this.props.user.bio.text,
+            picture: {},
+            changeDPText: "Upload"
         }
 
         this.cancelHandler = this.cancelHandler.bind(this);
         this.showProfilePicEdit = this.showProfilePicEdit.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleFileChange = this.handleFileChange.bind(this);
+
     }
 
     showProfilePicEdit(e) {
@@ -22,6 +33,100 @@ class EditBioPane extends React.Component {
         this.props.onCancel(e.target.value);
     };
 
+    handleFileChange = (event) => {
+        this.setState({picture: {"index": event.target.id, "name": event.target.name, "filename": event.target.value}});
+    }
+
+    firstnameChange = event => {
+        this.setState({
+            firstname: event.target.value
+        })
+    }
+
+    lastnameChange = event => {
+        this.setState({
+            lastname: event.target.value
+        })
+    }
+
+    bioChange = event => {
+        this.setState({
+            bio: event.target.value
+        })
+    }
+
+    handleSubmit = event => {
+        event.preventDefault();
+        this.setState({
+            saveBioText: "Saving..."
+        })
+
+        var nameBody = {
+            "firstname": this.state.firstname,
+            "lastname": this.state.lastname
+        }
+        var bioBody = {
+            "bio": this.state.bio
+        }
+
+        var config = {
+            headers: {
+                "x-auth-token": this.props.auth.token
+            }
+        }
+
+        axios.post(API_DOMAIN+"/profile/bio/update", bioBody, config)
+        .then(res => {
+            console.log(res);
+            if (this.state.firstname !== this.props.user.firstname || this.state.lastname !== this.props.user.lastname) {
+                axios.post(API_DOMAIN+"/profile/name/update", nameBody, config)
+                .then(res => {
+                    console.log(res);
+                    window.location.reload();
+                })
+                .catch(err => {
+                    console.log(err);
+                })
+            }
+            else {
+                window.location.reload();
+            }
+        })
+        .catch(err => {
+            console.log(err);
+        });
+    }
+
+    handleDPSubmit = event => {
+        event.preventDefault();
+
+        this.setState({
+            changeDPText: "Uploading..."
+        })
+
+        var input = document.getElementById(this.state.picture.index);
+        var fileBody = new FormData();
+        fileBody.append(this.state.picture.name, input.files[0]);
+
+        const fileConfig = {
+            headers: {
+                "accept": "application/json",
+                "Content-type": "multipart/form-data",
+                "x-auth-token": this.props.auth.token
+            }
+        }
+
+        axios.post(API_DOMAIN+"/users/uploadDP", fileBody, fileConfig)
+        .then(res => {
+            console.log(res);
+            window.location.reload();
+        })
+        .catch(err => {
+            console.log(err);
+        })
+    }
+
+
     render() {
         if (!this.props.showPane){
             return null;
@@ -30,32 +135,52 @@ class EditBioPane extends React.Component {
             <div className="editProjectsOverlay">
                 <div className="editProjectsOverlayContainer">
                 <div className="overlayButtonsContainer">
-                        <button className="cancelButton" onClick={this.cancelHandler}>Cancel</button>
-                    </div>
-                    <div className="editProjectsContainer">
-                        <form>
-                            <label>Name: </label>
-                            <br></br>
-                            <input type="text" placeholder="First name"/>
-                            <br></br>
-                            <input type="text" placeholder="Last name"/>
-                            <br></br>
-                            <label>Bio: </label>
-                            <br></br>
-                            <textarea placeholder=""/>
-                            <br></br>
-                            <button onClick={this.showProfilePicEdit}>Edit Profile Picture</button>
-                            {
-                                this.state.changePicture && (
-                                    <div>
-                                        <label>Upload Profile Picture: </label>
-                                        <input type="file"/>
+                    <button className="cancelButton" onClick={this.cancelHandler}><i class="material-icons">close</i></button> 
+                </div>
+                    {
+                        this.props.user && (
+                            <div className="editProjectsContainer">
+                                <div className="editBioForm">
+                                    <div className="column">
+                                        <h3>Profile Information</h3>
+                                        <form onSubmit={this.handleSubmit}>
+                                            <label>Name:</label>
+                                            <br></br>
+                                            <input type="text" onChange={this.firstnameChange} defaultValue={this.props.user.firstname}/>
+                                            <br></br>
+                                            <input type="text" onChange={this.lastnameChange} defaultValue={this.props.user.lastname}/>
+                                            <br></br>
+                                            <label>Bio: </label>
+                                            <br></br>
+                                            <textarea onChange={this.bioChange} defaultValue={this.props.user.bio.text}/>
+                                            <br></br>
+                                            <input type="submit" value={this.state.saveBioText} />
+                                            <br></br>
+                                        </form>
                                     </div>
-                                )
-                            }
-                            
-                        </form>
-                    </div>
+                                    <div className="column">
+                                        {/* <button onClick={this.showProfilePicEdit}>Change Profile Picture</button> */}
+                                        {/* {
+                                            this.state.changePicture && ( */}
+                                        <div>
+                                            <h3>Profile Picture</h3>
+                                            <img src={this.props.user.picture} alt="User Profile Picture" />
+                                            <form onSubmit={this.handleDPSubmit}>
+                                                <label>Upload Profile Picture: </label>
+                                                <br></br><br></br>
+                                                <input onChange={this.handleFileChange} type="file" id="dpUpload" name="userFile"/>
+                                                <br></br><br></br>
+                                                <input type="submit" value={this.state.changeDPText} />
+                                            </form>
+                                        </div>
+                                        {/* )
+                                            } */}
+                                    </div>
+                                </div>
+                            </div>
+                        )
+                    }
+                    
                     
 
                 </div>

--- a/src/user/editProjects/editProjectsPane.css
+++ b/src/user/editProjects/editProjectsPane.css
@@ -74,7 +74,7 @@
     text-align: center;
 }
 
-.editProjectForm {
+.editProjectForm, .editBioForm {
     box-sizing: border-box;
     margin: 5%;
 }
@@ -93,13 +93,13 @@
 }
 
 /* Clear floats after the columns */
-.editProjectForm:after {
+.editProjectForm:after, .editBioForm:after {
     content: "";
     display: table;
     clear: both;
 }
 
-.editProjectForm textarea, .projectButtonsContainer textarea {
+.editProjectForm textarea, .projectButtonsContainer textarea, .editBioForm textarea {
     width: 60%;
 	height: 120px;
 	border: 3px solid #cccccc;
@@ -142,4 +142,9 @@
 
 .attachment {
     list-style-type: none;
+}
+
+.editBioForm img {
+    max-width: 100%;
+    max-height: 200px;
 }

--- a/src/user/editProjects/listEntry.js
+++ b/src/user/editProjects/listEntry.js
@@ -413,15 +413,15 @@ class ListEntry extends React.Component {
                                     <h3>Project Information</h3>
                                     <label>Project Title: </label>
                                     <br></br><br></br>
-                                    <input type="text" onChange={this.titleChange} placeholder={this.props.project.title}/>
+                                    <input type="text" onChange={this.titleChange} defaultValue={this.props.project.title}/>
                                     <br></br><br></br>
                                     <label>Project Description: </label>
                                     <br></br><br></br>
-                                    <textarea placeholder={this.props.project.text} onChange={this.textChange}/>
+                                    <textarea defaultValue={this.props.project.text} onChange={this.textChange}/>
                                     <br></br><br></br>
                                     <label>Project Tags (comma separated, e.g. "software, tech, javascript"): </label>
                                     <br></br><br></br>
-                                    <textarea onChange={this.tagsChange} placeholder={this.props.project.tags} />
+                                    <textarea onChange={this.tagsChange} defaultValue={this.props.project.tags} />
                                     <br></br>
                                     <br></br>
                                     <input type="submit" value={this.state.saveProjectText} />

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -248,7 +248,7 @@ class ProfilePage extends React.Component {
         <div className="profileContainer">
           <NavBar userid={this.state.userid} isHome={false}/>
           <EditProjectsPane history={this.props.history} projects={userProjects} onCancel={this.closeEditPane} showPane={this.state.editPane}/>
-          <EditBioPane onCancel={this.closeBioPane} showPane={this.state.bioPane}/>
+          <EditBioPane history={this.props.history} auth={this.props.auth} user={this.state.userdata} onCancel={this.closeBioPane} showPane={this.state.bioPane}/>
           <div className="profilePageContainer">
             <div className="profileBody">
               <div className="profileBioBody">

--- a/src/user/profileBio.js
+++ b/src/user/profileBio.js
@@ -1,4 +1,3 @@
-import Axios from "axios";
 import React from "react";
 import axios from 'axios';
 import { API_DOMAIN } from "../config";
@@ -13,20 +12,40 @@ class ProfileBio extends React.Component {
             circleList: []
         }
 
+        this.renderCategory = this.renderCategory.bind(this);
+
         //this.mapCircle();
     }
 
+    
     componentDidMount() {
         this.mapCircle();
     }
-    getSnapshotBeforeUpdate() {
-        return this.state;
-    }
-    componentDidUpdate() {
-        var state = this.getSnapshotBeforeUpdate();
-        if (this.state !== state) {
-            this.mapCircle();
+
+    // Think this should fix the issue of a profile not updating given new parameters.
+    componentDidUpdate(prevProps) {
+        if (this.props.user !== prevProps.user) {
+          this.mapCircle();
+        };
+    };
+
+    renderCategory(userType) {
+        switch (userType) {
+            case "JOB_SEARCHER":
+                return (
+                    <h4><i className="material-icons">account_box</i> Job Searcher</h4>
+                )
+            case "RECRUITER":
+                return (
+                    <h4><i className="material-icons">account_circle</i> Employer/Recruiter</h4>
+                )
         }
+    }
+
+    listSocials(socials) {
+        return socials.map((social) => (
+            <a key={social} href={social}>{social}</a>
+        ))
     }
 
     getCircle() {
@@ -87,7 +106,9 @@ class ProfileBio extends React.Component {
     }
 
     render() {
+
         return (
+            
             <div className="bioContainer">
                 {/* Render name if it has been fetched from parent */}
                 {
@@ -108,6 +129,15 @@ class ProfileBio extends React.Component {
                             <img src="../noprofile.jpg" alt="Profile Picture" />
                        </div>
                    )
+                }
+                <hr />
+                {/* Render user type */}
+                {
+                    (this.props.user.bio) && (
+                        <div>
+                            <div>{this.renderCategory(this.props.user.bio.category)}</div>
+                        </div>
+                    )
                 }
                 <hr />
                 {/* Render description if it has been fetched from parent */} {/* Currently not in DB */}
@@ -142,6 +172,18 @@ class ProfileBio extends React.Component {
                    )
                 }
                 <hr />
+                {/* Render socials */}
+                {
+                    this.props.user.bio && (
+                        this.props.user.bio.socials.length > 0 && (
+                            <div>
+                                <h4>Links:</h4>
+                                <div>{this.listSocials(this.props.user.bio.socials)}</div>
+                            </div>
+                        )
+                    )
+                }
+                { /* Render circle */}
                 {
                     (this.props.user.circle.length > 0) ? (
                         <div>


### PR DESCRIPTION
This PR adds the features above as well as:
- Render socials if they exist (currently no way to update so it doesn't appear)
- Render user category (default is job searcher. Job searchers get a square icon while recruiters get a circle icon)
- Fetch user circle correctly on profile page change
- Default values of existing project and bio information in forms rather than placeholders

Need to:
- Add DP deletion
- Edit user category
- Edit user socials